### PR TITLE
Add check to return only an array

### DIFF
--- a/Services/ComparisonListFilter.php
+++ b/Services/ComparisonListFilter.php
@@ -26,7 +26,7 @@ class ComparisonListFilter implements ComparisonListFilterInterface
     {
         $hiddenOptionKeys = $this->config->getHiddenOptions();
 
-        if (null === $hiddenOptionKeys) {
+        if (empty($hiddenOptionKeys)) {
             return $comparisonList;
         }
 

--- a/Services/Config.php
+++ b/Services/Config.php
@@ -53,8 +53,17 @@ class Config implements ConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getHiddenOptions(): ?array
+    public function getHiddenOptions(): array
     {
-        return $this->get('hiddenOptions');
+        $hiddenOptions = $this->get('hiddenOptions');
+
+        if (null === $hiddenOptions) {
+            return [];
+        }
+
+        if (\is_array($hiddenOptions)) {
+            return $hiddenOptions;
+        }
+        return [$hiddenOptions];
     }
 }

--- a/Services/ConfigInterface.php
+++ b/Services/ConfigInterface.php
@@ -31,7 +31,7 @@ interface ConfigInterface
     public function set(string $key, string $value): void;
 
     /**
-     * @return int[]
+     * @return string[]
      */
-    public function getHiddenOptions(): ?array;
+    public function getHiddenOptions(): array;
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">nlxProductComparison</label>
     <label lang="en">nlxProductComparison</label>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <copyright>(c) by netlogix GmbH &amp; Co. KG</copyright>
     <license>Proprietary</license>
     <link>https://websolutions.netlogix.de/</link>
@@ -22,5 +22,9 @@
     <changelog version="1.0.2">
         <changes lang="de">Services definieren</changes>
         <changes lang="en">Define services</changes>
+    </changelog>
+    <changelog version="1.0.3">
+        <changes lang="de">Behandle "hiddenOptions" nur als ein Array um komplikationen zu vermeiden</changes>
+        <changes lang="en">Handle "hiddenOptions" only as an array to prevent complications</changes>
     </changelog>
 </plugin>

--- a/spec/Services/ComparisonListFilterSpec.php
+++ b/spec/Services/ComparisonListFilterSpec.php
@@ -48,7 +48,7 @@ class ComparisonListFilterSpec extends ObjectBehavior
                         2 => 'property2',
                         3 => 'property3',
                     ],
-                ]
+                ],
             ],
             'properties' => [
                 1 => 'test',
@@ -70,7 +70,7 @@ class ComparisonListFilterSpec extends ObjectBehavior
                         1 => 'property1',
                         2 => 'property2',
                     ],
-                ]
+                ],
             ],
             'properties' => [
                 1 => 'test',
@@ -85,12 +85,12 @@ class ComparisonListFilterSpec extends ObjectBehavior
             ->shouldBe($expectedResult);
     }
 
-    public function it_should_do_nothing_if_hidden_properties_are_null(ConfigInterface $config): void
+    public function it_should_do_nothing_if_hidden_properties_are_empty(ConfigInterface $config): void
     {
         $comparisonList = ['articles' => [], 'properties' => [1 => 'test', 2 => 'test2', 3 => 'test3']];
 
         $config->getHiddenOptions()
-            ->willReturn(null);
+            ->willReturn([]);
 
         $this->filterComparisonList($comparisonList)
             ->shouldBe($comparisonList);


### PR DESCRIPTION
It can happen that the config "hiddenOptions" is only a string and to prevent errors it should be converted to an array.